### PR TITLE
support discogs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+node_modules

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "Douban-Helper",
-    "version": "0.2",
+    "version": "0.3",
     "description": "豆瓣添加条目助手",
     "icons": {
       "48": "icons/icon-48.png"

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "douban-listing-helper",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "一键添加豆瓣条目 Create Douban listing with one click",
   "main": "background.js",
   "dependencies": {
-    "webextension-polyfill": "^0.7.0"
+    "webextension-polyfill": "^0.10.0"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
1. 优化了部分 js 代码风格和写法：`let` 替换为 `const`、空格之类...
2. 增加了对  discogs 专辑页面的支持（之前点了 collect 按钮会报错
3. 升级 `webextension-polyfill` 版本到 `0.10.0`

以及：有的 discogs 页面会有一个 id 为 `release_schema ` 的 `script`，可以优先取这里面的数据。如果没有，再从 dom 中逐个查找替换。（现在是优先 dom，看以后怎么处理好吧）